### PR TITLE
Fixes a bug when tooltip stays in the DOM forever

### DIFF
--- a/src/lib/tooltip.ts
+++ b/src/lib/tooltip.ts
@@ -190,6 +190,12 @@ export default (node: HTMLElement, options: Options) => {
 				}
 			},
 			destroy() {
+				if (TIP) {
+					node.removeAttribute('aria-describedby');
+					visible = false;
+					TIP.remove();
+					TIP = null;
+				}
 				window.removeEventListener('keydown', handleKeys);
 
 				onDestroy?.();


### PR DESCRIPTION
Fixes this issue: https://github.com/Gibbu/svooltip/issues/2#issuecomment-1477516295

When parent of the node directive is removed by svelte - we need to destroy DOM element.