### PR TITLE
fix: cannot change visibility if initialized with true

### DIFF
--- a/src/lib/tooltip.ts
+++ b/src/lib/tooltip.ts
@@ -184,7 +184,7 @@ export default (node: HTMLElement, options: Options) => {
 			update(props: Options) {
 				_content = props.content;
 				html = props.html || false;
-				_visibility = props.visibility || visibility;
+				_visibility = props.visibility ?? visibility;
 
 				if (TIP && TIPContent) {
 					TIPContent[html ? 'innerHTML' : 'textContent'] = _content;


### PR DESCRIPTION
Very tiny fix for a problem with the `update` method:

If `visibility` is set to `false` in the updated props, the `||` operator results in the initial value of `visibility` being used. In case `visibility` was set to `true` during initialization, that means it is not possible to disable the tooltip later.

This fix simply replaces `||` with `??`, to make sure the updated value is used as long as it is defined.